### PR TITLE
Home-page/browse-products-clean-up

### DIFF
--- a/src/app/components/home/browse-products-section.tsx
+++ b/src/app/components/home/browse-products-section.tsx
@@ -1,12 +1,12 @@
 'use client';
 import { PropsWithChildren } from 'react';
 import Image, { StaticImageData } from 'next/image';
+import Link from 'next/link';
 import { Item } from 'react-stately';
 import apparel from 'public/img/products/accessories/apparel.jpg';
 import armCuff from 'public/img/products/accessories/arm-cuff.jpg';
 import camLock from 'public/img/products/accessories/cam-lock.jpg';
 import counterWeight from 'public/img/products/accessories/counter-weight.jpg';
-import rubberWasher from 'public/img/products/accessories/rubber-washer.jpg';
 import coobCarbonFiberScoopHandle from 'public/img/products/coob/carbon-fiber-sand-scoop-handler-for-coob-scoops.jpeg';
 import xpDuesIICompleteShaft from 'public/img/products/deus/xp-deus-ii-complete-shaft.jpg';
 import garrettTwoPieceLowerShaft from 'public/img/products/garrett/garrett-two-piece-carbon-fiber-lower-shaft.jpg';
@@ -14,14 +14,20 @@ import minelabCarbonFiberSShaft from 'public/img/products/minelab/equinox-600-80
 import tarsacciCarbonFiberLowerRod from 'public/img/products/tarsacci/tarsacci-lower-rod.jpg';
 import PageHeader from 'src/app/components/runway/page-header';
 import { DivSectionWrapper } from 'src/app/components/runway/section-wrapper';
+import { Tabs } from 'src/app/components/runway/tab-list';
 import { clsx } from 'src/app/utils/clsx';
-import { Tabs } from '../runway/tab-list';
+import { CtaButtonLink } from '../runway/cta-button';
 
 type FeaturedProductProps = { img: StaticImageData; title: string; alt: string };
 
 function FeaturedProduct({ img, title, alt }: FeaturedProductProps) {
 	return (
-		<a
+		<Link
+			href={{
+				pathname: '/products',
+				// TODO - Handle deep linking into brands
+				query: {},
+			}}
 			className={clsx(
 				'relative aspect-[900/1000] flex-1 shrink-0 rounded-lg overflow-hidden',
 				'sm:hover:scale-105 transition duration-100 hover:cursor-pointer',
@@ -47,7 +53,7 @@ function FeaturedProduct({ img, title, alt }: FeaturedProductProps) {
 			>
 				<span className="font-medium text-2xl sm:text-3xl text-center text-white">{title}</span>
 			</div>
-		</a>
+		</Link>
 	);
 }
 
@@ -63,6 +69,11 @@ const featuredProducts: Record<Readonly<Exclude<TabOpts, 'All'>>, Readonly<Featu
 	Scoops: [
 		{
 			img: coobCarbonFiberScoopHandle,
+			alt: 'Stealth carbon fiber sand scoop handles',
+			title: 'Stealth',
+		},
+		{
+			img: coobCarbonFiberScoopHandle,
 			alt: 'CooB carbon fiber sand scoop handles',
 			title: 'CooB',
 		},
@@ -73,25 +84,14 @@ const featuredProducts: Record<Readonly<Exclude<TabOpts, 'All'>>, Readonly<Featu
 		},
 		{
 			img: coobCarbonFiberScoopHandle,
-			alt: 'Xtreme carbon fiber sand scoop handles',
-			title: 'Xtreme',
-		},
-		{
-			img: coobCarbonFiberScoopHandle,
-			alt: 'Stealth carbon fiber sand scoop handles',
-			title: 'Stealth',
-		},
-		{
-			img: coobCarbonFiberScoopHandle,
-			alt: 'T-Rex carbon fiber sand scoop handles',
-			title: 'T-Rex',
+			alt: 'CKG carbon fiber sand scoop handles',
+			title: 'CKG',
 		},
 	],
 	Accessories: [
 		{ img: counterWeight, alt: 'Counter weight for shafts', title: 'Counter Weight' },
 		{ img: armCuff, alt: 'Arm Cuffs fit for Steves Detector Rods Shafts', title: 'Arm Cuffs' },
-		{ img: camLock, alt: 'Replacement Cam Lock for SDR Shafts', title: 'Cam Lock' },
-		{ img: rubberWasher, alt: 'Replacement parts for any SDR Rods', title: 'Replacement Parts' },
+		{ img: camLock, alt: 'Replacement parts for any SDR Rods', title: 'Replacement Parts' },
 		{ img: apparel, alt: "Official Steve's Detector Rods Apparel", title: 'Apparel' },
 	],
 } as const;
@@ -108,6 +108,10 @@ function ProductGrid({ children }: PropsWithChildren<{}>) {
 	);
 }
 
+function TabSectionSubHeader({ children }: PropsWithChildren<{}>) {
+	return <p className="text-gray-700 text-lg mt-2 mb-6">{children}</p>;
+}
+
 export function BrowseProductsSection() {
 	return (
 		<DivSectionWrapper className="mt-4 sm:mt-8">
@@ -115,7 +119,9 @@ export function BrowseProductsSection() {
 			<Tabs aria-label="Browse Our Products" defaultSelectedKey="All" orientation="vertical">
 				<Item key="All" title="All">
 					<div>
-						<p className="text-gray-700 text-lg mt-3 mb-6">Refine your search below</p>
+						<TabSectionSubHeader>
+							Browse our expansive collection of high quality carbon-fiber metal detector rod and sand scoop add ons
+						</TabSectionSubHeader>
 						<ProductGrid>
 							{Object.values(featuredProducts)
 								.flat(1)
@@ -126,32 +132,53 @@ export function BrowseProductsSection() {
 					</div>
 				</Item>
 				<Item key="CompleteUpperShafts" title="Shafts">
-					<div>
-						<p className="text-gray-700 text-lg mt-3 mb-6">
+					<div className="flex flex-col">
+						<TabSectionSubHeader>
 							Select your detector brand from our list of available options below
-						</p>
+						</TabSectionSubHeader>
 						<ProductGrid>
 							{featuredProducts.Shafts.map((productProps) => (
 								<FeaturedProduct key={productProps.title} {...productProps} />
 							))}
 						</ProductGrid>
+						<CtaButtonLink size="md" className="mt-6 self-center w-full sm:w-auto text-center" href="/products">
+							Browse All Shafts
+						</CtaButtonLink>
+						<p className="text-xl text-gray-600 mt-4">
+							Don&apos;t see your brand listed? We may be able to customize to your needs! Send{' '}
+							<a className="text-red-800 hover:text-red-700" href="mailto:steve@stevesdetectorrods.com">
+								Steve an email
+							</a>
+							!
+						</p>
 					</div>
 				</Item>
 				<Item key="SandScoopHandles" title="Sand Scoop Handles">
-					<div>
-						<p className="text-gray-700 text-lg mt-3 mb-6">
-							Select your scoop brand from our list of available options below
-						</p>
+					<div className="flex flex-col">
+						<TabSectionSubHeader>Select your scoop brand from our list of available options below</TabSectionSubHeader>
 						<ProductGrid>
 							{featuredProducts.Scoops.map((productProps) => (
 								<FeaturedProduct key={productProps.title} {...productProps} />
 							))}
 						</ProductGrid>
+						<div className="flex flex-col sm:flex-row justify-center items-center gap-4 w-full mt-8">
+							<CtaButtonLink
+								size="md"
+								variant="secondary"
+								className="self-center w-full sm:w-auto text-center"
+								href="/products"
+							>
+								Browse Other Handles
+							</CtaButtonLink>
+							<CtaButtonLink size="md" className="self-center w-full sm:w-auto text-center" href="/products">
+								Browse All Handles
+							</CtaButtonLink>
+						</div>
 					</div>
 				</Item>
 				<Item key="Accessories" title="Accessories">
 					<div>
-						<p className="text-gray-700 text-lg mt-3 mb-6">
+						<p className="text-gray-700 text-lg mt-2 mb-6">
 							Replacement parts, counterweights, cuffs, official merch and more!
 						</p>
 						<ProductGrid>

--- a/src/app/components/navigation/sub-nav/sub-nav.tsx
+++ b/src/app/components/navigation/sub-nav/sub-nav.tsx
@@ -61,7 +61,7 @@ export default function SubNav() {
 				</MotionConfig>
 			</Portal>
 			<div
-				className="hidden sm:flex sticky top-[3.75rem]
+				className="hidden sm:flex sm:sticky sm:top-[3.75rem]
 							w-full bg-red-800 py-2 justify-center z-[1]"
 			>
 				<div className={clsx('flex flex-row justify-between w-full space-x-4', 'px-4 lg:px-12 xl:px-20')}>

--- a/src/app/components/runway/cta-button.tsx
+++ b/src/app/components/runway/cta-button.tsx
@@ -3,16 +3,18 @@ import { HTMLProps, PropsWithChildren, useRef } from 'react';
 import { AriaLinkOptions, useLink } from '@react-aria/link';
 import { clsx } from 'src/app/utils/clsx';
 
-type ColorVariant = 'primary';
+type ColorVariant = 'primary' | 'secondary';
 
 const colorVariantClasses: Record<ColorVariant, string> = {
-	primary: 'bg-red-700 hover:bg-red-800',
+	primary: 'bg-red-700 hover:bg-red-800 text-white',
+	secondary: 'bg-gray-200 hover:bg-gray-300 text-black',
 };
 
-type Size = 'lg' | 'sm';
+type Size = 'sm' | 'md' | 'lg';
 
 const sizeClasses: Record<Size, string> = {
 	lg: 'px-12 sm:px-16 py-2 sm:py-3 rounded-xl text-lg sm:text-xl lg:text-2xl',
+	md: 'px-8 sm:px-12 py-1.5 sm:py-2 rounded-xl text-lg lg:text-xl',
 	sm: 'px-6 py-1.5 rounded-lg text-md lg:text-lg',
 };
 
@@ -42,7 +44,7 @@ export function CtaButtonLink({
 			ref={ref}
 			href={href}
 			target={target}
-			className={clsx(colorVariantClasses[variant], sizeClasses[size], 'transition-colors 100ms text-white', className)}
+			className={clsx(colorVariantClasses[variant], sizeClasses[size], 'transition-colors 100m', className)}
 			{...linkProps}
 		>
 			{children}

--- a/src/app/components/runway/section-wrapper.tsx
+++ b/src/app/components/runway/section-wrapper.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import { clsx } from 'src/app/utils/clsx';
 
 export function MainSectionWrapper({ className = '', children }: PropsWithChildren<{ className?: string }>) {
-	return <main className={clsx('px-4 lg:px-12 xl:px-20 w-full', className)}>{children}</main>;
+	return <main className={clsx('px-4 lg:px-12 xl:px-20', className)}>{children}</main>;
 }
 
 export function DivSectionWrapper({ className = '', children }: PropsWithChildren<{ className?: string }>) {

--- a/src/app/components/runway/tab-list.tsx
+++ b/src/app/components/runway/tab-list.tsx
@@ -20,24 +20,10 @@ function Tab({
 	return (
 		<div
 			className={clsx(
-				'relative text-lg whitespace-nowrap',
-				'py-1 sm:py-1.5 px-2 sm:px-1 w-full sm:w-min',
-				'hover:cursor-pointer',
-				"after:content-[''] after:absolute after:block after:h-[2px] after:mt-1.5",
-				'after:transition-all after:duration-[0.2s]',
-				...(isSelected
-					? [
-							'sm:after:w-[100%] sm:after:left-0 sm:after:bg-red-800 sm:text-red-800 sm:bg-transparent sm:rounded-none',
-							'font-normal',
-							'bg-red-800 text-white rounded-lg',
-					  ]
-					: [
-							'font-light',
-							'sm:hover:after:w-[100%] sm:hover:after:left-0 sm:hover:after:bg-red-600 sm:hover:text-red-700',
-							// eslint-disable-next-line max-len
-							'sm:after:w-0 sm:after:right-0 sm:after:bg-red-700 sm:after:text-red-700',
-					  ]),
-				'outline-red-700',
+				'relative text-xl sm:text-lg whitespace-nowrap',
+				'hover:cursor-pointer transition-colors duration-150',
+				isSelected ? 'text-red-800' : 'hover:text-red-700',
+				'focus:outline-none',
 			)}
 			{...tabProps}
 			onClick={() => {
@@ -51,7 +37,17 @@ function Tab({
 			}}
 			ref={tabRef}
 		>
-			{rendered}
+			<div className="px-3 py-1.5">{rendered}</div>
+			{/*
+			 * When you inevitably come back and want to fix this, using layoutId and motion.div is currently broken in the
+			 * Next 13 app directory. The issue below is probably what will fix this. Test it on:
+			 * 1. Chrome
+			 * 2. Chrome on a small viewport browser
+			 * 3. Safari (all sizes)
+			 *
+			 * https://github.com/vercel/next.js/issues/49279
+			 */}
+			<div className={clsx('bg-red-800 h-[2px] w-full', isSelected ? 'visible' : 'invisible')} />
 		</div>
 	);
 }
@@ -73,13 +69,13 @@ const orientationTabListClasses: Record<Orientation, string> = {
 
 const orientationTabClasses: Record<Orientation, string> = {
 	horizontal: 'flex-col',
-	vertical: 'flex-row sm:border-b-2 space-y-2 sm:space-y-0 sm:space-x-6',
+	vertical: 'flex-row',
 };
 
 export function Tabs(props: AriaTabListProps<AriaTabProps>) {
 	const state = useTabListState(props);
-	const tabsRef = useRef(null);
-	const { tabListProps } = useTabList(props, state, tabsRef);
+	const tabsContainerRef = useRef(null);
+	const { tabListProps } = useTabList(props, state, tabsContainerRef);
 
 	const { orientation = 'horizontal' } = props;
 
@@ -87,11 +83,11 @@ export function Tabs(props: AriaTabListProps<AriaTabProps>) {
 		<div className={clsx('flex w-full', orientationTabListClasses[orientation])}>
 			<div
 				className={clsx(
-					'flex flex-col sm:flex-row justify-start items-center overflow-x-auto sm:overflow-x-clip',
+					'flex justify-start items-center border-b-[1px] border-gray-300 space-x-2 overflow-x-auto',
 					orientationTabClasses[orientation],
 				)}
 				{...tabListProps}
-				ref={tabsRef}
+				ref={tabsContainerRef}
 			>
 				{[...state.collection].map((item: Node<AriaTabProps>) => (
 					<Tab key={item.key} item={item} state={state} orientation={orientation} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { clsx } from './utils/clsx';
 
 function HeroSection() {
 	return (
-		<div className="relative h-[50vh]">
+		<div className="relative">
 			<Image
 				src={rollingLandscape}
 				alt="Landscape shot of rolling hills"
@@ -22,9 +22,9 @@ function HeroSection() {
 			/>
 			<div
 				className={clsx(
-					'absolute flex flex-col w-full h-full max-w-[100vw] sm:max-w-[70%] justify-center',
+					'relative flex flex-col max-w-[100vw] sm:max-w-[70%] justify-center',
 					'bg-black bg-opacity-20 sm:bg-opacity-0',
-					'px-4 lg:px-12 xl:px-20',
+					'px-4 lg:px-12 xl:px-20 py-12 lg:py-24',
 				)}
 			>
 				<h2
@@ -33,14 +33,13 @@ function HeroSection() {
 						'md:text-4xl md:leading-10',
 						'lg:text-5xl lg:leading-[3.25rem]',
 						'text-white font-normal',
-						'my-2 rounded-xl',
 					)}
 				>
 					Your home for <b>premium-quality</b>, custom-made <b>carbon-fiber</b> metal detector rods and shafts
 				</h2>
 				<CtaButtonLink
 					href="products"
-					className="mt-6 sm:mt-8 flex content-center self-center sm:self-start justify-center"
+					className="mt-8 sm:mt-8 flex content-center self-center sm:self-start justify-center"
 				>
 					<MdOutlineShoppingCart className="mt-[0.3125rem] sm:mt-1" />
 					<span className="ml-2 lg:ml-3">Shop Now</span>


### PR DESCRIPTION
This PR:
- Updates the Hero section on the landing page to properly format on shorter browsers, allowing it to scale vertically instead of being a fixed width

| Before | After |
| ---- | ---- |
| <img width="1512" alt="image" src="https://github.com/steves-detector-rods/app/assets/6293510/ee3b9909-6a1a-4b56-85e3-c816f9973cd8"> | <img width="1512" alt="image" src="https://github.com/steves-detector-rods/app/assets/6293510/c04da97d-b26d-4054-ad95-2450e7fb0a86"> |

- Updates the tabbing animation on the browse products section to not break on Safari and small screens

| | |
| ---- | ---- |
| <img width="1512" alt="image" src="https://github.com/steves-detector-rods/app/assets/6293510/54db4352-7c49-4c5d-ad08-1bf5ec450339"> | <img width="1512" alt="image" src="https://github.com/steves-detector-rods/app/assets/6293510/ac3c2621-8dfb-4e7a-909a-0d322f1f0ee9"> |

- Minor display updates to the tabs for better accessibility
- Updated CTAs on Scoops and Shafts sections to handle edge case users better
