### PR TITLE
Home-page/performance-fixes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
 	experimental: {
 		appDir: true,
 	},
+	productionBrowserSourceMaps: true,
 };
 
 module.exports = nextConfig;

--- a/src/app/components/home/browse-products-section.tsx
+++ b/src/app/components/home/browse-products-section.tsx
@@ -39,6 +39,7 @@ function FeaturedProduct({ img, title, alt }: FeaturedProductProps) {
 				placeholder="blur"
 				loading="lazy"
 				fill
+				sizes="(max-width: 850px) 50vw, (max-width: 1190px) 33vw, 25vw"
 				style={{
 					objectFit: 'fill',
 					objectPosition: 'center',

--- a/src/app/components/runway/section-wrapper.tsx
+++ b/src/app/components/runway/section-wrapper.tsx
@@ -2,9 +2,9 @@ import { PropsWithChildren } from 'react';
 import { clsx } from 'src/app/utils/clsx';
 
 export function MainSectionWrapper({ className = '', children }: PropsWithChildren<{ className?: string }>) {
-	return <main className={clsx('px-4 lg:px-12 xl:px-20', className)}>{children}</main>;
+	return <main className={clsx('px-4 lg:px-12 xl:px-20 w-full', className)}>{children}</main>;
 }
 
 export function DivSectionWrapper({ className = '', children }: PropsWithChildren<{ className?: string }>) {
-	return <div className={clsx('px-4 lg:px-12 xl:px-20', className)}>{children}</div>;
+	return <div className={clsx('px-4 lg:px-12 xl:px-20 w-full', className)}>{children}</div>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ function HeroSection() {
 				quality={100}
 				fill
 				placeholder="blur"
+				sizes="100vw"
 				style={{
 					objectFit: 'cover',
 					objectPosition: 'center',


### PR DESCRIPTION
This PR handles a few errors being logged to the concole by Next.JS.

- Enabled production browser source maps (lighthouse requested)
- Adds the sizes props to Next images using fill to reduce load time by serving the correct width file
- Fixes a bug introduced in my last PR where the FAQ page doesn't fill the width of the browser